### PR TITLE
Remove unnecessary test dependency nose-cov

### DIFF
--- a/templates/test.sh.jj2
+++ b/templates/test.sh.jj2
@@ -1,2 +1,2 @@
 pip freeze
-nosetests --with-cov --cov pyexcel_{{nick_name}} --cov tests --with-doctest --doctest-extension=.rst tests README.rst pyexcel_{{nick_name}}
+nosetests --with-cov --cover-package pyexcel_{{nick_name}} --cover-package tests --with-doctest --doctest-extension=.rst tests README.rst pyexcel_{{nick_name}}

--- a/templates/tests/requirements.txt.jj2
+++ b/templates/tests/requirements.txt.jj2
@@ -1,5 +1,4 @@
 nose
-nose-cov
 codecov
 coverage
 {%block extras %}


### PR DESCRIPTION
nose comes with with coverage support pre-installed,
and it becomes functional when coverage is also installed.

nose-cov only adds a little sugar, but it requires a more
recent version of nose than is packaged in Debian.
