### PR TITLE
Fix environment markers

### DIFF
--- a/templates/setup.py.jj2
+++ b/templates/setup.py.jj2
@@ -37,7 +37,7 @@ EXTRAS_REQUIRE = {
   {% endfor %}
   {% for dependency in dependencies: %}
   {%   if ';' in dependency: %}
-  '{{dependency.split(';')[1].strip()}}': [
+  ':{{dependency.split(';')[1].strip()}}': [
     '{{dependency.split(';')[0].strip()}}'
   ],
   {%   endif %}


### PR DESCRIPTION
baf8dfc did not include the leading ':' needed for
setuptools extra_requires.
