### PR TITLE
Pin setuptools==17.1 to install rnd_requirements

### DIFF
--- a/templates/travis.yml.jj2
+++ b/templates/travis.yml.jj2
@@ -21,7 +21,10 @@ python:
 before_install:
 {% block custom_install %}
 {% endblock%}
-  - if [[ -f rnd_requirements.txt ]]; then pip install -r rnd_requirements.txt; fi
+  - if [[ -f rnd_requirements.txt ]]; then
+      pip install --upgrade "setuptools==17.1" ;
+      pip install -r rnd_requirements.txt ;
+    fi
   - pip install -r tests/requirements.txt
 script:
   make test


### PR DESCRIPTION
rnd_requirements.txt uses .zip dependencies that
now utilise environment markers from #7.

setuptools before 17.1 causes pip to fail with:

```
error in <x> setup command: Invalid environment marker: <y>
```
