### PR TITLE
Improved rnd_requirements and min_requirements

### DIFF
--- a/templates/min_requirements.txt.jj2
+++ b/templates/min_requirements.txt.jj2
@@ -1,0 +1,14 @@
+{% for dependency in dependencies: %}
+{%     if dependency.startswith('texttable'): %}
+{# See https://github.com/foutaise/texttable/issues/5 #}
+{%         if ';' in dependency: %}
+texttable==0.8.3;{{dependency.split(';')[1]}}
+{%         else: %}
+texttable==0.8.3
+{%         endif %}
+{%     elif ';' in dependency: %}
+{{dependency.split(';')[0].replace('>=', '==').replace('>', '==') + ';' + dependency.split(';')[1]}}
+{%     else: %}
+{{dependency.replace('>=', '==').replace('>', '==')}}
+{%     endif %}
+{% endfor %}

--- a/templates/travis.yml.jj2
+++ b/templates/travis.yml.jj2
@@ -21,10 +21,12 @@ python:
 before_install:
 {% block custom_install %}
 {% endblock%}
-  - if [[ -f rnd_requirements.txt ]]; then
-      pip install --upgrade "setuptools==17.1" "pip==7.1" ;
-      pip install -r rnd_requirements.txt ;
+  - if [[ -f min_requirements.txt && "$MINREQ" -eq 1 ]]; then
+      mv min_requirements.txt requirements.txt ;
     fi
+  - test ! -f rnd_requirements.txt || pip install --upgrade "setuptools" "pip==7.1"
+  - test ! -f rnd_requirements.txt || pip install --no-deps -r rnd_requirements.txt
+  - test ! -f rnd_requirements.txt || pip install -r rnd_requirements.txt ;
   - pip install -r tests/requirements.txt
 script:
   make test


### PR DESCRIPTION
Allow installing . for `pyexcel` in rnd_requirements,
which fails with setuptoos 17.1 so that is upgraded to the
latest version.

Also add a MINREQ mode with a min_requirements.txt template
to generate a requirements.txt that requires the minimum
version instead of allowing pip to install the latest version,
to ensure that the minimum requirements are in fact still
supported.

And workaround the fact that texttable 0.8.1 and 0.8.2
are not located in pypi or github.
