### PR TITLE
:fire: remove copilot as contributor as github does not have its url

### DIFF
--- a/config/pyexcel.yaml
+++ b/config/pyexcel.yaml
@@ -22,3 +22,4 @@ language: Python
 lint_command: make lint
 excluded_github_users:
   - chfw
+  - Copilot


### PR DESCRIPTION
copilot as contributor fails contributors.rst generation